### PR TITLE
 SCSS: Remove redundant main.bundle import to fix persistent Errors

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -2,9 +2,6 @@
 ---
 
 @use 'main';
-{%- if jekyll.environment == 'production' -%}
-  @use 'main.bundle';
-{%- endif -%}
 
 /* append your custom style below */
 


### PR DESCRIPTION
Chirpy SCSS: Remove redundant main.bundle import to fix persistent Github build pages error